### PR TITLE
fix #2 InvocationTargetException is thrown when there exists a method without return type in @Mapper interfaces

### DIFF
--- a/processor/src/main/kotlin/io/github/olxmute/processor/BuilderProcessor.kt
+++ b/processor/src/main/kotlin/io/github/olxmute/processor/BuilderProcessor.kt
@@ -27,6 +27,7 @@ class BuilderProcessor : AbstractProcessor() {
         val types = roundEnv.getElementsAnnotatedWith(Class.forName("org.mapstruct.Mapper") as Class<Annotation>)
             .asSequence()
             .flatMap { ElementFilter.methodsIn(it.enclosedElements) }
+            .filter { it.returnType is DeclaredType }
             .map { it.returnType as DeclaredType }
             .map { it.asElement() as TypeElement }
             .filter { it.isDataClass() }


### PR DESCRIPTION
This PR fixes issue #2.